### PR TITLE
fix: Swiper slider, remove unnecessary imports

### DIFF
--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -1,71 +1,74 @@
-import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { collection, getDocs, query, orderBy, limit } from 'firebase/firestore'
-import { db } from '../firebase.config'
-import SwiperCore, { Navigation, Pagination, Scrollbar, A11y } from 'swiper'
-import { Swiper, SwiperSlide } from 'swiper/react'
-import 'swiper/swiper-bundle.css'
-import Spinner from './Spinner'
-SwiperCore.use([Navigation, Pagination, Scrollbar, A11y])
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { collection, getDocs, query, orderBy, limit } from "firebase/firestore";
+import { db } from "../firebase.config";
+import Spinner from "./Spinner";
+
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Pagination } from "swiper/modules";
+import "swiper/css";
+import "swiper/css/pagination";
 
 function Slider() {
-  const [loading, setLoading] = useState(true)
-  const [listings, setListings] = useState(null)
+  const [loading, setLoading] = useState(true);
+  const [listings, setListings] = useState(null);
+  console.log("listing", listings);
 
-  const navigate = useNavigate()
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchListings = async () => {
-      const listingsRef = collection(db, 'listings')
-      const q = query(listingsRef, orderBy('timestamp', 'desc'), limit(5))
-      const querySnap = await getDocs(q)
+      const listingsRef = collection(db, "listings");
+      const q = query(listingsRef, orderBy("timestamp", "desc"), limit(5));
+      const querySnap = await getDocs(q);
 
-      let listings = []
+      let listings = [];
 
       querySnap.forEach((doc) => {
         return listings.push({
           id: doc.id,
           data: doc.data(),
-        })
-      })
+        });
+      });
 
-      setListings(listings)
-      setLoading(false)
-    }
+      setListings(listings);
+      setLoading(false);
+    };
 
-    fetchListings()
-  }, [])
+    fetchListings();
+  }, []);
 
   if (loading) {
-    return <Spinner />
+    return <Spinner />;
   }
 
   if (listings.length === 0) {
-    return <></>
+    return <></>;
   }
 
   return (
     listings && (
       <>
-        <p className='exploreHeading'>Recommended</p>
-
-        <Swiper slidesPerView={1} pagination={{ clickable: true }}>
+        <p className="exploreHeading">Recommended</p>
+        <Swiper
+          pagination={{ clickable: true }}
+          modules={[Pagination]}
+          className="home-slider"
+        >
           {listings.map(({ data, id }) => (
-            <SwiperSlide
-              key={id}
-              onClick={() => navigate(`/category/${data.type}/${id}`)}
-            >
+            <SwiperSlide key={id}>
               <div
                 style={{
                   background: `url(${data.imgUrls[0]}) center no-repeat`,
-                  backgroundSize: 'cover',
+                  backgroundSize: "cover",
+                  height: "200px",
                 }}
-                className='swiperSlideDiv'
+                className="swiperSlideDiv"
               >
-                <p className='swiperSlideText'>{data.name}</p>
-                <p className='swiperSlidePrice'>
-                  ${data.discountedPrice ?? data.regularPrice}{' '}
-                  {data.type === 'rent' && '/ month'}
+                <p className="swiperSlideText">{data.name}</p>
+                <p className="swiperSlidePrice">
+                  ${data.discountedPrice ?? data.regularPrice}{" "}
+                  {data.type === "rent" && "/ month"}
                 </p>
               </div>
             </SwiperSlide>
@@ -73,7 +76,7 @@ function Slider() {
         </Swiper>
       </>
     )
-  )
+  );
 }
 
-export default Slider
+export default Slider;

--- a/src/pages/Listing.jsx
+++ b/src/pages/Listing.jsx
@@ -2,15 +2,17 @@ import { useState, useEffect } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { Helmet } from 'react-helmet'
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet'
-import SwiperCore, { Navigation, Pagination, Scrollbar, A11y } from 'swiper'
+// import SwiperCore, { Navigation, Pagination, Scrollbar, A11y } from 'swiper'
 import { Swiper, SwiperSlide } from 'swiper/react'
-import 'swiper/swiper-bundle.css'
+// import 'swiper/swiper-bundle.css'
 import { getDoc, doc } from 'firebase/firestore'
 import { getAuth } from 'firebase/auth'
 import { db } from '../firebase.config'
 import Spinner from '../components/Spinner'
 import shareIcon from '../assets/svg/shareIcon.svg'
-SwiperCore.use([Navigation, Pagination, Scrollbar, A11y])
+// SwiperCore.use([Navigation, Pagination, Scrollbar, A11y])
+// import { Swiper, SwiperSlide } from "swiper/react";
+// import { Pagination } from "swiper/modules";
 
 function Listing() {
   const [listing, setListing] = useState(null)


### PR DESCRIPTION
1. Update Swiper import statements for improved compatibility.
2. Use 'swiper-bundle.min.css' for styling.
3. Remove unnecessary imports.